### PR TITLE
Config Firefox Data Collection

### DIFF
--- a/config/firefox/user.js
+++ b/config/firefox/user.js
@@ -6,6 +6,13 @@
 
 // === Startup ===
 
+// Open previous windows and tabs
+// 0 : Blank Page
+// 1 : Home Page
+// 2 : Last Session
+// 3: Home Page or Last Session
+user_pref("browser.startup.page", 3);
+
 // Always check if Firefox is your default browser
 user_pref("browser.shell.checkDefaultBrowser", false);
 

--- a/config/firefox/user.js
+++ b/config/firefox/user.js
@@ -343,10 +343,10 @@ user_pref("xpinstall.whitelist.required", true);
 user_pref("datareporting.healthreport.uploadEnabled", false);
 
 // Allow Firefox to make personalized extension recommendations
-// user_pref("browser.discovery.enabled", false);
+user_pref("browser.discovery.enabled", false);
 
 // Allow Firefox to install and run studies
-// user_pref("app.shield.optoutstudies.enabled", false);
+user_pref("app.shield.optoutstudies.enabled", false);
 
 // Allow Firefox to send backlogged crash reports on your behalf
 user_pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false);
@@ -354,7 +354,7 @@ user_pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false);
 // == Website Advertising Preferences ==
 
 // Allow websites to perform privacy-preserving ad measurement
-// user_pref("null", false);
+user_pref("dom.private-attribution.submission.enabled", false);
 
 // == Security ==
 

--- a/config/firefox/user.js
+++ b/config/firefox/user.js
@@ -340,13 +340,13 @@ user_pref("xpinstall.whitelist.required", true);
 // == Firefox Data Collection and Use ==
 
 // Allow Firefox to send technical and interaction data to Mozilla
-// user_pref("null", false);
+user_pref("datareporting.healthreport.uploadEnabled", false);
 
 // Allow Firefox to make personalized extension recommendations
-// user_pref("null", false);
+// user_pref("browser.discovery.enabled", false);
 
 // Allow Firefox to install and run studies
-// user_pref("null", false);
+// user_pref("app.shield.optoutstudies.enabled", false);
 
 // Allow Firefox to send backlogged crash reports on your behalf
 user_pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false);


### PR DESCRIPTION
Set options in the "Firefox Data Collection and Use" and "Website Advertising Preferences" sections, as well as setting the startup page setting.

Fix #6 